### PR TITLE
Support for 1.16.4 + Error chat msg if /etf command has 0 args.

### DIFF
--- a/EntityTrackerFixer/plugin.yml
+++ b/EntityTrackerFixer/plugin.yml
@@ -1,6 +1,6 @@
 name: EntityTrackerFixer
 main: net.minemora.entitytrackerfixer.EntityTrackerFixer
-version: 1.3.2
+version: 1.3.3
 softdepend: [Vault]
 api-version: 1.14
 author: Esmorall
@@ -8,7 +8,7 @@ description: Untrack entities that are not used at all by the server.
 commands:
   entitytrackerfixer:
     aliases: [etf]
-    description: Main Command of EntityTrackerFixer
+    description: Main Command of EntityTrackerFixer.
     usage: /etf
 permissions:
   entitytrackerfixer.*:

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -10,23 +10,23 @@ import org.bukkit.entity.Player;
 
 public class CommandETF implements CommandExecutor {
 
-    @Override
-    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
-        if (commandSender instanceof Player) {
-            if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
-                commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
-                return true;
-            }
-        }
-        if (args.length == 0) {
-            commandSender.sendMessage(ChatColor.RED + "No arguments provided. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
-            return true;
-        }
-        if (args[0].equalsIgnoreCase("reload")) {
-            EntityTrackerFixer.plugin.reload();
-            commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
-        }
-	commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
-        return true;
-    }
+	@Override
+	public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
+		if (commandSender instanceof Player) {
+			if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
+				commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
+				return true;
+			}
+		}
+		if (args.length == 0) {
+			commandSender.sendMessage(ChatColor.RED + "No arguments provided. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+			return true;
+		}
+		if (args[0].equalsIgnoreCase("reload")) {
+			EntityTrackerFixer.plugin.reload();
+			commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
+		}
+		commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+		return true;
+	}
 }

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -26,6 +26,7 @@ public class CommandETF implements CommandExecutor {
             EntityTrackerFixer.plugin.reload();
             commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
         }
+		commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
         return true;
     }
 }

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -1,32 +1,31 @@
 package net.minemora.entitytrackerfixer.commands;
 
+import net.minemora.entitytrackerfixer.EntityTrackerFixer;
+import net.minemora.entitytrackerfixer.vault.VaultManager;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import net.minemora.entitytrackerfixer.EntityTrackerFixer;
-import net.minemora.entitytrackerfixer.vault.VaultManager;
-
 public class CommandETF implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
-    	if(args.length == 0) {
-    		return true;
-    	}
-    	if(args[0].equalsIgnoreCase("reload")) {
-    		if(commandSender instanceof Player) {
-        		if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
-                    commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
-                    return true;
-                }
-        	}
-    		EntityTrackerFixer.plugin.reload();
-    		commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
-    	}
-        
-		return true;
+        if (commandSender instanceof Player) {
+            if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
+                commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
+                return true;
+            }
+        }
+        if (args.length == 0) {
+            commandSender.sendMessage(ChatColor.RED + "No arguments provided. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("reload")) {
+            EntityTrackerFixer.plugin.reload();
+            commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
+        }
+        return true;
     }
 }

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -25,6 +25,7 @@ public class CommandETF implements CommandExecutor {
 		if (args[0].equalsIgnoreCase("reload")) {
 			EntityTrackerFixer.plugin.reload();
 			commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
+			return true;
 		}
 		commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
 		return true;

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -10,24 +10,24 @@ import org.bukkit.entity.Player;
 
 public class CommandETF implements CommandExecutor {
 
-	@Override
-	public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
-		if (commandSender instanceof Player) {
-			if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
-				commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
-				return true;
-			}
-		}
-		if (args.length == 0) {
-			commandSender.sendMessage(ChatColor.RED + "No arguments provided. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
-			return true;
-		}
-		if (args[0].equalsIgnoreCase("reload")) {
-			EntityTrackerFixer.plugin.reload();
-			commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
-			return true;
-		}
-		commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
-		return true;
-	}
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
+        if (commandSender instanceof Player) {
+            if (!VaultManager.hasPermission((Player) commandSender, "entitytrackerfixer.reload")) {
+                commandSender.sendMessage(ChatColor.RED + "You don't have permission to use that command.");
+                return true;
+            }
+        }
+        if (args.length == 0) {
+            commandSender.sendMessage(ChatColor.RED + "No arguments provided. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("reload")) {
+            EntityTrackerFixer.plugin.reload();
+            commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded successfully!");
+            return true;
+        }
+        commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+        return true;
+    }
 }

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/commands/CommandETF.java
@@ -26,7 +26,7 @@ public class CommandETF implements CommandExecutor {
             EntityTrackerFixer.plugin.reload();
             commandSender.sendMessage(ChatColor.GREEN + "The config has been reloaded sucessfully!");
         }
-		commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
+	commandSender.sendMessage(ChatColor.RED + "Invalid argument. Available: " + ChatColor.GOLD + "/etf reload" + ChatColor.RED + ".");
         return true;
     }
 }

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/NMSEntityTracker.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/NMSEntityTracker.java
@@ -1,0 +1,49 @@
+package net.minemora.entitytrackerfixer.v1_16_R3;
+
+import net.minecraft.server.v1_16_R3.ChunkProviderServer;
+import net.minecraft.server.v1_16_R3.PlayerChunkMap;
+import net.minemora.entitytrackerfixer.util.ReflectionUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public final class NMSEntityTracker {
+
+    private static Method addEntityMethod;
+    private static Method removeEntityMethod;
+
+    static {
+        try {
+            addEntityMethod = ReflectionUtils.getPrivateMethod(PlayerChunkMap.class, "addEntity",
+                    new Class[]{net.minecraft.server.v1_16_R3.Entity.class});
+            removeEntityMethod = ReflectionUtils.getPrivateMethod(PlayerChunkMap.class, "removeEntity",
+                    new Class[]{net.minecraft.server.v1_16_R3.Entity.class});
+        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private NMSEntityTracker() {
+    }
+
+    public static void trackEntities(ChunkProviderServer cps, Set<net.minecraft.server.v1_16_R3.Entity> trackList) {
+        try {
+            for (net.minecraft.server.v1_16_R3.Entity entity : trackList) {
+                addEntityMethod.invoke(cps.playerChunkMap, entity);
+            }
+        } catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void untrackEntities(ChunkProviderServer cps, Set<net.minecraft.server.v1_16_R3.Entity> untrackList) {
+        try {
+            for (net.minecraft.server.v1_16_R3.Entity entity : untrackList) {
+                removeEntityMethod.invoke(cps.playerChunkMap, entity);
+            }
+        } catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/NMSHandler.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/NMSHandler.java
@@ -1,0 +1,22 @@
+package net.minemora.entitytrackerfixer.v1_16_R3;
+
+import net.minemora.entitytrackerfixer.config.ConfigMain;
+import net.minemora.entitytrackerfixer.nms.NMS;
+import net.minemora.entitytrackerfixer.v1_16_R3.tasks.CheckTask;
+import net.minemora.entitytrackerfixer.v1_16_R3.tasks.UntrackerTask;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+public class NMSHandler implements NMS {
+
+    @Override
+    public BukkitTask startUntrackerTask(Plugin plugin) {
+        return new UntrackerTask().runTaskTimer(plugin, ConfigMain.getUntrackTicks(), ConfigMain.getUntrackTicks());
+    }
+
+    @Override
+    public BukkitTask startUCheckTask(Plugin plugin) {
+        return new CheckTask().runTaskTimer(plugin, ConfigMain.getUntrackTicks() + 1, ConfigMain.getCheckFrequency());
+    }
+
+}

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/entityTick/EntityTickManager.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/entityTick/EntityTickManager.java
@@ -1,0 +1,71 @@
+package net.minemora.entitytrackerfixer.v1_16_R3.entityTick;
+
+import net.minecraft.server.v1_16_R3.EntityInsentient;
+import net.minecraft.server.v1_16_R3.MinecraftServer;
+import net.minemora.entitytrackerfixer.EntityTrackerFixer;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+import java.util.Set;
+
+public class EntityTickManager implements Listener {
+
+    private static EntityTickManager instance;
+
+    private EntityTickManager() {
+        EntityTrackerFixer.plugin.getServer().getPluginManager().registerEvents(this, EntityTrackerFixer.plugin);
+    }
+
+    public static EntityTickManager getInstance() {
+        if (instance == null) {
+            instance = new EntityTickManager();
+        }
+        return instance;
+    }
+
+    public void disableTicking(net.minecraft.server.v1_16_R3.Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (!entity.valid) {
+            return;
+        }
+        entity.activatedTick = -2147483648L;
+        if (entity instanceof EntityInsentient) {
+            //System.out.println("disable tick for insentient entity currently aware is = " + ((EntityInsentient)entity).aware + " should be true");
+            ((EntityInsentient) entity).aware = false;
+        }
+    }
+
+    public void enableTicking(Set<net.minecraft.server.v1_16_R3.Entity> entities) {
+        for (net.minecraft.server.v1_16_R3.Entity entity : entities) {
+            if (entity == null) {
+                continue;
+            }
+            if (!entity.valid) {
+                continue;
+            }
+            entity.activatedTick = MinecraftServer.currentTick;
+            if (entity instanceof EntityInsentient) {
+                //System.out.println("enabling tick for insentient entity currently aware is = " + ((EntityInsentient)entity).aware + " should be false");
+                ((EntityInsentient) entity).aware = true;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent event) {
+        for (Entity entity : event.getChunk().getEntities()) {
+            net.minecraft.server.v1_16_R3.Entity nms = ((CraftEntity) entity).getHandle();
+            if (nms instanceof EntityInsentient) {
+                if (!((EntityInsentient) nms).aware) {
+                    ((EntityInsentient) nms).aware = true;
+                }
+            }
+        }
+    }
+
+}

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/CheckTask.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/CheckTask.java
@@ -1,0 +1,62 @@
+package net.minemora.entitytrackerfixer.v1_16_R3.tasks;
+
+import net.minecraft.server.v1_16_R3.ChunkProviderServer;
+import net.minecraft.server.v1_16_R3.WorldServer;
+import net.minemora.entitytrackerfixer.config.ConfigMain;
+import net.minemora.entitytrackerfixer.v1_16_R3.NMSEntityTracker;
+import net.minemora.entitytrackerfixer.v1_16_R3.entityTick.EntityTickManager;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class CheckTask extends BukkitRunnable {
+
+    @Override
+    public void run() {
+        if (UntrackerTask.isRunning()) {
+            return;
+        }
+        if (ConfigMain.isEnableOnAllWorlds()) {
+            for (World world : Bukkit.getWorlds()) {
+                checkWorld(world.getName());
+            }
+        } else {
+            for (String worldName : ConfigMain.getWorlds()) {
+                if (Bukkit.getWorld(worldName) == null) {
+                    continue;
+                }
+                checkWorld(worldName);
+            }
+        }
+    }
+
+    public void checkWorld(String worldName) {
+        WorldServer ws = ((CraftWorld) Bukkit.getWorld(worldName)).getHandle();
+        ChunkProviderServer cps = ws.getChunkProvider();
+
+        Set<net.minecraft.server.v1_16_R3.Entity> trackAgain = new HashSet<>();
+
+        int d = ConfigMain.getTrackingRange();
+        for (Player player : Bukkit.getWorld(worldName).getPlayers()) {
+            for (Entity ent : player.getNearbyEntities(d, d, d)) {
+                net.minecraft.server.v1_16_R3.Entity nms = ((CraftEntity) ent).getHandle();
+                if (cps.playerChunkMap.trackedEntities.containsKey(nms.getId()) || !nms.valid) {
+                    continue;
+                }
+                trackAgain.add(nms);
+            }
+        }
+        NMSEntityTracker.trackEntities(cps, trackAgain);
+        if (ConfigMain.isDisableTickUntracked()) {
+            EntityTickManager.getInstance().enableTicking(trackAgain);
+        }
+    }
+
+}

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/UntrackerTask.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/UntrackerTask.java
@@ -1,0 +1,114 @@
+package net.minemora.entitytrackerfixer.v1_16_R3.tasks;
+
+import net.minecraft.server.v1_16_R3.*;
+import net.minecraft.server.v1_16_R3.PlayerChunkMap.EntityTracker;
+import net.minemora.entitytrackerfixer.EntityTrackerFixer;
+import net.minemora.entitytrackerfixer.config.ConfigMain;
+import net.minemora.entitytrackerfixer.util.ReflectionUtils;
+import net.minemora.entitytrackerfixer.v1_16_R3.entityTick.EntityTickManager;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+public class UntrackerTask extends BukkitRunnable {
+
+    private static boolean running = false;
+
+    private static Field trackerField;
+
+    static {
+        try {
+            trackerField = ReflectionUtils.getClassPrivateField(EntityTracker.class, "tracker");
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static boolean isRunning() {
+        return running;
+    }
+
+    @SuppressWarnings({"deprecation", "resource"})
+    @Override
+    public void run() {
+        if (MinecraftServer.getServer().recentTps[0] > ConfigMain.getMinTps()) {
+            return;
+        }
+        running = true;
+        if (ConfigMain.isEnableOnAllWorlds()) {
+            for (World world : Bukkit.getWorlds()) {
+                untrackProcess(world.getName());
+            }
+        } else {
+            for (String worldName : ConfigMain.getWorlds()) {
+                untrackProcess(worldName);
+            }
+        }
+
+        running = false;
+    }
+
+    private void untrackProcess(String worldName) {
+        if (Bukkit.getWorld(worldName) == null) {
+            return;
+        }
+        //Set<net.minecraft.server.v1_14_R3.Entity> toRemove = new HashSet<>();
+        Set<Integer> toRemove = new HashSet<>();
+        int removed = 0;
+        WorldServer ws = ((CraftWorld) Bukkit.getWorld(worldName)).getHandle();
+        ChunkProviderServer cps = ws.getChunkProvider();
+
+        try {
+            for (EntityTracker et : cps.playerChunkMap.trackedEntities.values()) {
+                net.minecraft.server.v1_16_R3.Entity nmsEnt = (net.minecraft.server.v1_16_R3.Entity) trackerField.get(et);
+                if (nmsEnt instanceof EntityPlayer || nmsEnt instanceof EntityEnderDragon || nmsEnt instanceof EntityComplexPart) {
+                    continue;
+                }
+                if (nmsEnt instanceof EntityArmorStand && nmsEnt.getBukkitEntity().getCustomName() != null) {
+                    continue;
+                }
+                boolean remove = false;
+                if (et.trackedPlayers.size() == 0) {
+                    remove = true;
+                } else if (et.trackedPlayers.size() == 1) {
+                    for (EntityPlayer ep : et.trackedPlayers) {
+                        if (!ep.getBukkitEntity().isOnline()) {
+                            remove = true;
+                        }
+                    }
+                    if (!remove) {
+                        continue;
+                    }
+                }
+                if (remove) {
+                    //System.out.println("untracked: " + nmsEnt.getBukkitEntity().getType().name());
+                    toRemove.add(nmsEnt.getId());
+                    removed++;
+                }
+            }
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        for (int id : toRemove) {
+            cps.playerChunkMap.trackedEntities.remove(id);
+            if (ConfigMain.isDisableTickUntracked()) {
+                EntityTickManager.getInstance().disableTicking(ws.entitiesById.get(id));
+            }
+        }
+
+        if (ConfigMain.isLogToConsole()) {
+            if (removed > 0) {
+                EntityTrackerFixer.plugin.getLogger().info("Untracked " + removed + " entities in " + worldName);
+            }
+        }
+
+        //System.out.println("cache now contains " + UntrackedEntitiesCache.getInstance().getCache(worldName).size() + " entities");
+    }
+
+}

--- a/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/UntrackerTask.java
+++ b/EntityTrackerFixer/src/net/minemora/entitytrackerfixer/v1_16_R3/tasks/UntrackerTask.java
@@ -57,7 +57,7 @@ public class UntrackerTask extends BukkitRunnable {
         if (Bukkit.getWorld(worldName) == null) {
             return;
         }
-        //Set<net.minecraft.server.v1_14_R3.Entity> toRemove = new HashSet<>();
+        //Set<net.minecraft.server.v1_14_R2.Entity> toRemove = new HashSet<>();
         Set<Integer> toRemove = new HashSet<>();
         int removed = 0;
         WorldServer ws = ((CraftWorld) Bukkit.getWorld(worldName)).getHandle();

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # EntityTrackerFixer
 Untrack entities that are not used at all by the server
 
-Did you try everything to fix the lag on your server 1.14.4 or 1.15 but it is still lagging?
+Did you try everything to fix the lag on your server 1.14.4 or 1.16.4 but it is still lagging?
 Do timings indicate some random entity is causing lag?
 
-This plugin may help you
+This plugin may help you.
+Available from 1.14.4 to 1.16.4.
 
 How does it works?
-Minecraft tracks a lot of entities, even if they are outside the tracking range of the player, that's a normal behavior but is a tps killer for 1.14.4 and 1.15 servers with more than 30 players. So what this plugin do is untrack those entities every configured ticks and track them again if the player is near.
+Minecraft tracks a lot of entities, even if they are outside the tracking range of the player, that's a normal behavior but is a tps killer for 1.14.4 and 1.16.4 servers with more than 30 players. So what this plugin do is untrack those entities every configured ticks and track them again if the player is near.
 
 Report any bug in the issues section.
 


### PR DESCRIPTION
This adds support for version 1.16.4 (1_16_R3), updates README.md and it also adds an error chat message if the /etf command is used with 0 arguments. Added message is "No arguments provided. Available: /etf reload."

Download compiled file here: https://unserversinley.net/misc/jars/EntityTrackerFixer-1.16.4.jar
Have a nice day.